### PR TITLE
Fix off by one error

### DIFF
--- a/quantum/xap/handlers/lighting.c
+++ b/quantum/xap/handlers/lighting.c
@@ -178,7 +178,7 @@ bool xap_respond_direct_mode_set_multiple_leds(xap_token_t token, const void *da
         return false;
 
     // Check bounds on the ending point
-    if ((led_count < 1) || (starting_led + led_count) >= RGB_MATRIX_LED_COUNT)
+    if ((led_count < 1) || (starting_led + led_count) > RGB_MATRIX_LED_COUNT)
         return false;
 
     // Make sure we have enough data to actually set the LEDs
@@ -226,7 +226,7 @@ bool xap_respond_direct_mode_set_multiple_leds(xap_token_t token, const void *da
         return false;
 
     // Check bounds on the ending point
-    if ((starting_led + led_count) >= RGB_MATRIX_LED_COUNT)
+    if ((starting_led + led_count) > RGB_MATRIX_LED_COUNT)
         return false;
 
     // Make sure we have enough data to actually set the LEDs


### PR DESCRIPTION
This fixes the off by one error discovered while testing POC direct mode in OpenRGB


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Requires changes in OpenRGB (found at https://gitlab.com/CoffeeIsLife/OpenRGB/-/merge_requests/1)
